### PR TITLE
Added Selenium test scripts based on Page Object Patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,795 +1,852 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <name>petclinic</name>
+	<name>petclinic</name>
 
-    <groupId>deors.demos</groupId>
-    <artifactId>deors.demos.petclinic</artifactId>
-    <packaging>war</packaging>
-    <version>1.0-SNAPSHOT</version>
+	<groupId>deors.demos</groupId>
+	<artifactId>deors.demos.petclinic</artifactId>
+	<packaging>war</packaging>
+	<version>1.0-SNAPSHOT</version>
 
-    <properties>
-        <java.version>1.8</java.version>
+	<properties>
+		<java.version>1.8</java.version>
 
-        <servlet.version>2.5.0</servlet.version>
-        <jsp.version>2.1.0</jsp.version>
-        <jstl.version>1.2.0</jstl.version>
-        <taglibs.version>1.1.2</taglibs.version>
-        <jaxb.version>2.1.7</jaxb.version>
-        <jta.version>1.1.0</jta.version>
-        <jpa.version>1.0.0</jpa.version>
+		<servlet.version>2.5.0</servlet.version>
+		<jsp.version>2.1.0</jsp.version>
+		<jstl.version>1.2.0</jstl.version>
+		<taglibs.version>1.1.2</taglibs.version>
+		<jaxb.version>2.1.7</jaxb.version>
+		<jta.version>1.1.0</jta.version>
+		<jpa.version>1.0.0</jpa.version>
 
-        <spring.version>3.0.6.RELEASE</spring.version>
-        <aspectj.version>1.6.8.RELEASE</aspectj.version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <log4j.version>2.6.2</log4j.version>
-        <commons-dbcp.version>1.2.2.osgi</commons-dbcp.version>
-        <commons-pool.version>1.5.3</commons-pool.version>
-        <hibernate.version>3.3.2.GA</hibernate.version>
-        <hibernate-jpa.version>3.4.0.GA</hibernate-jpa.version>
-        <toplink.version>2.0.0.b41-beta2</toplink.version>
-        <openjpa.version>1.1.0</openjpa.version>
-        <syndication.version>1.0.0</syndication.version>
-        <jdom.version>1.1.0</jdom.version>
+		<spring.version>3.0.6.RELEASE</spring.version>
+		<aspectj.version>1.6.8.RELEASE</aspectj.version>
+		<slf4j.version>1.7.21</slf4j.version>
+		<log4j.version>2.6.2</log4j.version>
+		<commons-dbcp.version>1.2.2.osgi</commons-dbcp.version>
+		<commons-pool.version>1.5.3</commons-pool.version>
+		<hibernate.version>3.3.2.GA</hibernate.version>
+		<hibernate-jpa.version>3.4.0.GA</hibernate-jpa.version>
+		<toplink.version>2.0.0.b41-beta2</toplink.version>
+		<openjpa.version>1.1.0</openjpa.version>
+		<syndication.version>1.0.0</syndication.version>
+		<jdom.version>1.1.0</jdom.version>
 
-        <hsqldb.version>1.8.0.9</hsqldb.version>
-        <mysql.version>5.1.6</mysql.version>
-        <postgresql.version>9.1-901.jdbc4</postgresql.version>
-        <mongojava.version>2.12.2</mongojava.version>
+		<hsqldb.version>1.8.0.9</hsqldb.version>
+		<mysql.version>5.1.6</mysql.version>
+		<postgresql.version>9.1-901.jdbc4</postgresql.version>
+		<mongojava.version>2.12.2</mongojava.version>
 
-        <junit.version>4.12</junit.version>
-        <selenium.version>2.53.1</selenium.version>
-        <htmlunit.version>2.18</htmlunit.version>
-        <pitest.version>1.1.5</pitest.version>
-        <embedmongo.version>0.1.12</embedmongo.version>
-        <mongodb.version>2.6.7</mongodb.version>
+		<junit.version>4.12</junit.version>
+		<selenium.version>2.53.1</selenium.version>
+		<htmlunit.version>2.18</htmlunit.version>
+		<pitest.version>1.1.5</pitest.version>
+		<embedmongo.version>0.1.12</embedmongo.version>
+		<mongodb.version>2.6.7</mongodb.version>
 
-        <jacoco.version>0.7.5.201505241946</jacoco.version>
-        <jacoco.path>${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar</jacoco.path>
-        <jacoco.utReport>${project.build.directory}/jacoco.exec</jacoco.utReport>
-        <jacoco.itReport>${project.build.directory}/jacoco-it.exec</jacoco.itReport>
-        <jacoco.utAgentConfig>-javaagent:${jacoco.path}=destfile=${jacoco.utReport}</jacoco.utAgentConfig>
-        <jacoco.itAgentConfig>-javaagent:${jacoco.path}=destfile=${jacoco.itReport}</jacoco.itAgentConfig>
+		<jacoco.version>0.7.5.201505241946</jacoco.version>
+		<jacoco.path>${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.version}/org.jacoco.agent-${jacoco.version}-runtime.jar</jacoco.path>
+		<jacoco.utReport>${project.build.directory}/jacoco.exec</jacoco.utReport>
+		<jacoco.itReport>${project.build.directory}/jacoco-it.exec</jacoco.itReport>
+		<jacoco.utAgentConfig>-javaagent:${jacoco.path}=destfile=${jacoco.utReport}</jacoco.utAgentConfig>
+		<jacoco.itAgentConfig>-javaagent:${jacoco.path}=destfile=${jacoco.itReport}</jacoco.itAgentConfig>
 
-        <jacoco-listeners.version>3.5</jacoco-listeners.version>
+		<jacoco-listeners.version>3.5</jacoco-listeners.version>
 
-        <tomcat.version>8.0.30</tomcat.version>
-        <tomcat.downloadUrl>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</tomcat.downloadUrl>
+		<tomcat.version>8.0.30</tomcat.version>
+		<tomcat.downloadUrl>http://archive.apache.org/dist/tomcat/tomcat-8/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</tomcat.downloadUrl>
 
-        <wildfly.version>10.0.0.Final</wildfly.version>
-        <wildfly.downloadUrl>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</wildfly.downloadUrl>
+		<wildfly.version>10.0.0.Final</wildfly.version>
+		<wildfly.downloadUrl>http://download.jboss.org/wildfly/${wildfly.version}/wildfly-${wildfly.version}.zip</wildfly.downloadUrl>
 
-        <jetty.version>9.3.6.v20151106</jetty.version>
-        <jetty.downloadUrl>http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/jetty-distribution-${jetty.version}.zip</jetty.downloadUrl>
+		<jetty.version>9.3.6.v20151106</jetty.version>
+		<jetty.downloadUrl>http://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/jetty-distribution-${jetty.version}.zip</jetty.downloadUrl>
 
-        <!-- overriding sonar.sources properties to enable multi-language analysis -->
-        <sonar.sources>src/main</sonar.sources>
-        <org.sonar.plugins.jmeter.jtlpath>${project.build.directory}/jmeter/results/petclinic.jtl</org.sonar.plugins.jmeter.jtlpath>
-    </properties>
+		<!-- overriding sonar.sources properties to enable multi-language analysis -->
+		<sonar.sources>src/main</sonar.sources>
+		<org.sonar.plugins.jmeter.jtlpath>${project.build.directory}/jmeter/results/petclinic.jtl</org.sonar.plugins.jmeter.jtlpath>
+	</properties>
 
-    <dependencies>
-        <!-- Spring -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.context</artifactId>
-            <version>${spring.version}</version>
-            <exclusions>
-                <!-- Exclude Commons Logging in favor of SLF4j -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>com.springsource.org.apache.commons.logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.orm</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.oxm</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.web.servlet</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.aspects</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
-        <!-- AspectJ -->
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>com.springsource.org.aspectj.weaver</artifactId>
-            <version>${aspectj.version}</version>
-        </dependency>
+	<dependencies>
+		<!-- Spring -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.context</artifactId>
+			<version>${spring.version}</version>
+			<exclusions>
+				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>com.springsource.org.apache.commons.logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.orm</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.oxm</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.web.servlet</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.aspects</artifactId>
+			<version>${spring.version}</version>
+		</dependency>
+		<!-- AspectJ -->
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>com.springsource.org.aspectj.weaver</artifactId>
+			<version>${aspectj.version}</version>
+		</dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-            <scope>runtime</scope>
-        </dependency>
+		<!-- Logging -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 
-        <!-- DataSource -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>com.springsource.org.apache.commons.dbcp</artifactId>
-            <version>${commons-dbcp.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>com.springsource.org.apache.commons.pool</artifactId>
-            <version>${commons-pool.version}</version>
-            <scope>runtime</scope>
-        </dependency>
+		<!-- DataSource -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>com.springsource.org.apache.commons.dbcp</artifactId>
+			<version>${commons-dbcp.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>com.springsource.org.apache.commons.pool</artifactId>
+			<version>${commons-pool.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 
-        <!-- Database drivers -->
-        <!-- HSQLDB JDBC Connector -->
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>com.springsource.org.hsqldb</artifactId>
-            <version>${hsqldb.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <!-- MySQL JDBC Connector -->
-        <dependency>
-            <groupId>com.mysql.jdbc</groupId>
-            <artifactId>com.springsource.com.mysql.jdbc</artifactId>
-            <version>${mysql.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <!-- PostgreSQL JDB Connector -->
-        <dependency>
-            <groupId>postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <!--  MongoDB  -->
-        <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>${mongojava.version}</version>
-        </dependency>
+		<!-- Database drivers -->
+		<!-- HSQLDB JDBC Connector -->
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>com.springsource.org.hsqldb</artifactId>
+			<version>${hsqldb.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- MySQL JDBC Connector -->
+		<dependency>
+			<groupId>com.mysql.jdbc</groupId>
+			<artifactId>com.springsource.com.mysql.jdbc</artifactId>
+			<version>${mysql.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- PostgreSQL JDB Connector -->
+		<dependency>
+			<groupId>postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<version>${postgresql.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<!-- MongoDB -->
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongo-java-driver</artifactId>
+			<version>${mongojava.version}</version>
+		</dependency>
 
-        <!-- Hibernate -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>com.springsource.org.hibernate</artifactId>
-            <version>${hibernate.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>com.springsource.slf4j.api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<!-- Hibernate -->
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>com.springsource.org.hibernate</artifactId>
+			<version>${hibernate.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>com.springsource.slf4j.api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <!-- JPA -->
-        <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>com.springsource.javax.persistence</artifactId>
-            <version>${jpa.version}</version>
-        </dependency>
-        <!-- Hibernate JPA Provider -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>com.springsource.org.hibernate.ejb</artifactId>
-            <version>${hibernate-jpa.version}</version>
-            <exclusions>
-                <!-- Exclude Commons Logging in favor of SLF4j -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>com.springsource.org.apache.commons.logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>com.springsource.slf4j.api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>com.springsource.org.hibernate.annotations</artifactId>
-            <version>${hibernate-jpa.version}</version>
-            <exclusions>
-                <!-- Exclude Commons Logging in favor of SLF4j -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>com.springsource.org.apache.commons.logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>com.springsource.slf4j.api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- Toplink JPA Provider -->
-        <dependency>
-            <groupId>com.oracle.toplink.essentials</groupId>
-            <artifactId>com.springsource.oracle.toplink.essentials</artifactId>
-            <version>${toplink.version}</version>
-        </dependency>
-        <!-- Open JPA Provider -->
-        <dependency>
-            <groupId>org.apache.openjpa</groupId>
-            <artifactId>com.springsource.org.apache.openjpa</artifactId>
-            <version>${openjpa.version}</version>
-            <exclusions>
-                <!-- Exclude Commons Logging in favor of SLF4j -->
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>com.springsource.org.apache.commons.logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<!-- JPA -->
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>com.springsource.javax.persistence</artifactId>
+			<version>${jpa.version}</version>
+		</dependency>
+		<!-- Hibernate JPA Provider -->
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>com.springsource.org.hibernate.ejb</artifactId>
+			<version>${hibernate-jpa.version}</version>
+			<exclusions>
+				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>com.springsource.org.apache.commons.logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>com.springsource.slf4j.api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>com.springsource.org.hibernate.annotations</artifactId>
+			<version>${hibernate-jpa.version}</version>
+			<exclusions>
+				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>com.springsource.org.apache.commons.logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>com.springsource.slf4j.api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- Toplink JPA Provider -->
+		<dependency>
+			<groupId>com.oracle.toplink.essentials</groupId>
+			<artifactId>com.springsource.oracle.toplink.essentials</artifactId>
+			<version>${toplink.version}</version>
+		</dependency>
+		<!-- Open JPA Provider -->
+		<dependency>
+			<groupId>org.apache.openjpa</groupId>
+			<artifactId>com.springsource.org.apache.openjpa</artifactId>
+			<version>${openjpa.version}</version>
+			<exclusions>
+				<!-- Exclude Commons Logging in favor of SLF4j -->
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>com.springsource.org.apache.commons.logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <!-- Servlet -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>com.springsource.javax.servlet</artifactId>
-            <version>${servlet.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>com.springsource.javax.servlet.jsp</artifactId>
-            <version>${jsp.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>com.springsource.javax.servlet.jsp.jstl</artifactId>
-            <version>${jstl.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.taglibs</groupId>
-            <artifactId>com.springsource.org.apache.taglibs.standard</artifactId>
-            <version>${taglibs.version}</version>
-        </dependency>
+		<!-- Servlet -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>com.springsource.javax.servlet</artifactId>
+			<version>${servlet.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>com.springsource.javax.servlet.jsp</artifactId>
+			<version>${jsp.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>com.springsource.javax.servlet.jsp.jstl</artifactId>
+			<version>${jstl.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.taglibs</groupId>
+			<artifactId>com.springsource.org.apache.taglibs.standard</artifactId>
+			<version>${taglibs.version}</version>
+		</dependency>
 
-        <!-- Rome RSS -->
-        <dependency>
-            <groupId>com.sun.syndication</groupId>
-            <artifactId>com.springsource.com.sun.syndication</artifactId>
-            <version>${syndication.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>com.springsource.org.jdom</artifactId>
-            <version>${jdom.version}</version>
-            <scope>runtime</scope>
-        </dependency>
+		<!-- Rome RSS -->
+		<dependency>
+			<groupId>com.sun.syndication</groupId>
+			<artifactId>com.springsource.com.sun.syndication</artifactId>
+			<version>${syndication.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jdom</groupId>
+			<artifactId>com.springsource.org.jdom</artifactId>
+			<version>${jdom.version}</version>
+			<scope>runtime</scope>
+		</dependency>
 
-        <!-- JAXB -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>com.springsource.javax.xml.bind</artifactId>
-            <version>${jaxb.version}</version>
-            <scope>provided</scope>
-        </dependency>
+		<!-- JAXB -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>com.springsource.javax.xml.bind</artifactId>
+			<version>${jaxb.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <version>${selenium.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>${htmlunit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.test</artifactId>
-            <version>${spring.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.transaction</groupId>
-            <artifactId>com.springsource.javax.transaction</artifactId>
-            <version>${jta.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>org.jacoco.agent</artifactId>
-            <version>${jacoco.version}</version>
-            <classifier>runtime</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.sonarsource.java</groupId>
-            <artifactId>sonar-jacoco-listeners</artifactId>
-            <version>${jacoco-listeners.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-java</artifactId>
+			<version>${selenium.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.sourceforge.htmlunit</groupId>
+			<artifactId>htmlunit</artifactId>
+			<version>${htmlunit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>org.springframework.test</artifactId>
+			<version>${spring.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.transaction</groupId>
+			<artifactId>com.springsource.javax.transaction</artifactId>
+			<version>${jta.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.agent</artifactId>
+			<version>${jacoco.version}</version>
+			<classifier>runtime</classifier>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.sonarsource.java</groupId>
+			<artifactId>sonar-jacoco-listeners</artifactId>
+			<version>${jacoco-listeners.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-    <repositories>
-        <repository>
-            <id>com.springsource.repository.bundles.release</id>
-            <name>SpringSource Enterprise Bundle Repository - SpringSource Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/release</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.external</id>
-            <name>SpringSource Enterprise Bundle Repository - External Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/external</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.milestone</id>
-            <name>SpringSource Enterprise Bundle Repository - SpringSource Milestones</name>
-            <url>http://repository.springsource.com/maven/bundles/milestone</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.snapshot</id>
-            <name>SpringSource Enterprise Bundle Repository - Snapshot Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/snapshot</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>com.springsource.repository.bundles.release</id>
+			<name>SpringSource Enterprise Bundle Repository - SpringSource Releases</name>
+			<url>http://repository.springsource.com/maven/bundles/release</url>
+		</repository>
+		<repository>
+			<id>com.springsource.repository.bundles.external</id>
+			<name>SpringSource Enterprise Bundle Repository - External Releases</name>
+			<url>http://repository.springsource.com/maven/bundles/external</url>
+		</repository>
+		<repository>
+			<id>com.springsource.repository.bundles.milestone</id>
+			<name>SpringSource Enterprise Bundle Repository - SpringSource Milestones</name>
+			<url>http://repository.springsource.com/maven/bundles/milestone</url>
+		</repository>
+		<repository>
+			<id>com.springsource.repository.bundles.snapshot</id>
+			<name>SpringSource Enterprise Bundle Repository - Snapshot Releases</name>
+			<url>http://repository.springsource.com/maven/bundles/snapshot</url>
+		</repository>
+	</repositories>
 
-    <build>
-        <finalName>petclinic</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
-                <configuration>
-                    <!-- JDK 7 - relax bytecode verifier to prevent double -->
-                    <!-- instrumentation issues with OpenJPA tests and JaCoCo -->
-                    <!-- <argLine>-XX:-UseSplitVerifier ${jacoco.utAgentConfig}</argLine> -->
-                    <!-- JDK 8 - bytecode verifier cannot be relaxed or disabled -->
-                    <!-- to prevent runtime errors, OpenJPA tests are ignored -->
-                    <argLine>${jacoco.utAgentConfig}</argLine>
-                    <includes>
-                        <include>**/*Test.java</include>
-                        <include>**/*Tests.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/it/*IT.java</exclude>
-                        <exclude>**/mongo/*IT.java</exclude>
-                    </excludes>
-                    <properties>
-                        <!-- add SonarQube's JaCoCo listener to enable -->
-                        <!-- gathering of code coverage metrics per test -->
-                        <property>
-                            <name>listener</name>
-                            <value>org.sonar.java.jacoco.JUnitListener</value>
-                        </property>
-                    </properties>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <warName>petclinic</warName>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<finalName>petclinic</finalName>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.17</version>
+				<configuration>
+					<!-- JDK 7 - relax bytecode verifier to prevent double -->
+					<!-- instrumentation issues with OpenJPA tests and JaCoCo -->
+					<!-- <argLine>-XX:-UseSplitVerifier ${jacoco.utAgentConfig}</argLine> -->
+					<!-- JDK 8 - bytecode verifier cannot be relaxed or disabled -->
+					<!-- to prevent runtime errors, OpenJPA tests are ignored -->
+					<argLine>${jacoco.utAgentConfig}</argLine>
+					<includes>
+						<include>**/*Test.java</include>
+						<include>**/*Tests.java</include>
+					</includes>
+					<excludes>
+						<exclude>**/it/*IT.java</exclude>
+						<exclude>**/mongo/*IT.java</exclude>
+					</excludes>
+					<properties>
+						<!-- add SonarQube's JaCoCo listener to enable -->
+						<!-- gathering of code coverage metrics per test -->
+						<property>
+							<name>listener</name>
+							<value>org.sonar.java.jacoco.JUnitListener</value>
+						</property>
+					</properties>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+				<version>2.3</version>
+				<configuration>
+					<warName>petclinic</warName>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
-    <profiles>
-        <!-- When built in OpenShift the 'openshift' profile will be used when invoking mvn. -->
-        <!-- Use this profile for any OpenShift specific customization your app will need. -->
-        <!-- By default that is to put the resulting archive into the 'deployments' folder. -->
-        <!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
-        <profile>
-            <id>openshift</id>
-            <build>
-                <finalName>petclinic</finalName>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-war-plugin</artifactId>
-                        <version>2.3</version>
-                        <configuration>
-                            <outputDirectory>deployments</outputDirectory>
-                            <warName>ROOT</warName>
-                            <webResources>
-                                <resource>
-                                    <!-- copy OpenShift specific resources -->
-                                    <!-- this is relative to where the pom.xml file is -->
-                                    <directory>src/main/resources/openshift</directory>
-                                    <targetPath>WEB-INF/classes</targetPath>
-                                </resource>
-                            </webResources>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+	<profiles>
+		<!-- When built in OpenShift the 'openshift' profile will be used when
+			invoking mvn. -->
+		<!-- Use this profile for any OpenShift specific customization your app
+			will need. -->
+		<!-- By default that is to put the resulting archive into the 'deployments'
+			folder. -->
+		<!-- http://maven.apache.org/guides/mini/guide-building-for-different-environments.html -->
+		<profile>
+			<id>openshift</id>
+			<build>
+				<finalName>petclinic</finalName>
+				<plugins>
+					<plugin>
+						<artifactId>maven-war-plugin</artifactId>
+						<version>2.3</version>
+						<configuration>
+							<outputDirectory>deployments</outputDirectory>
+							<warName>ROOT</warName>
+							<webResources>
+								<resource>
+									<!-- copy OpenShift specific resources -->
+									<!-- this is relative to where the pom.xml file is -->
+									<directory>src/main/resources/openshift</directory>
+									<targetPath>WEB-INF/classes</targetPath>
+								</resource>
+							</webResources>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- Activated only when building on Heroku -->
-        <profile>
-            <id>heroku</id>
-            <activation>
-                <file>
-                    <exists>/app/tmp/cache/.maven/bin/mvn</exists>
-                </file>
-            </activation>
-            <build>
-                <finalName>petclinic</finalName>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-war-plugin</artifactId>
-                        <version>2.3</version>
-                        <configuration>
-                            <webResources>
-                                <resource>
-                                    <!-- copy Heroku specific resources -->
-                                    <!-- this is relative to where the pom.xml file is -->
-                                    <directory>src/main/resources/heroku</directory>
-                                    <targetPath>WEB-INF/classes</targetPath>
-                                </resource>
-                            </webResources>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>2.4</version>
-                        <executions>
-                            <execution>
-                                <id>package</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.mortbay.jetty</groupId>
-                                            <artifactId>jetty-runner</artifactId>
-                                            <version>8.1.3.v20120416</version>
-                                            <destFileName>jetty-runner.jar</destFileName>
-                                        </artifactItem>
-                                        <!-- not available in jetty-runner 8.1.3 -->
-                                        <artifactItem>
-                                            <groupId>javax.servlet</groupId>
-                                            <artifactId>com.springsource.javax.servlet.jsp.jstl</artifactId>
-                                            <version>1.2.0</version>
-                                            <destFileName>jstl.jar</destFileName>
-                                        </artifactItem>
-                                        <artifactItem>
-                                            <groupId>org.apache.taglibs</groupId>
-                                            <artifactId>com.springsource.org.apache.taglibs.standard</artifactId>
-                                            <version>1.1.2</version>
-                                            <destFileName>standard.jar</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- Activated only when building on Heroku -->
+		<profile>
+			<id>heroku</id>
+			<activation>
+				<file>
+					<exists>/app/tmp/cache/.maven/bin/mvn</exists>
+				</file>
+			</activation>
+			<build>
+				<finalName>petclinic</finalName>
+				<plugins>
+					<plugin>
+						<artifactId>maven-war-plugin</artifactId>
+						<version>2.3</version>
+						<configuration>
+							<webResources>
+								<resource>
+									<!-- copy Heroku specific resources -->
+									<!-- this is relative to where the pom.xml file is -->
+									<directory>src/main/resources/heroku</directory>
+									<targetPath>WEB-INF/classes</targetPath>
+								</resource>
+							</webResources>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<version>2.4</version>
+						<executions>
+							<execution>
+								<id>package</id>
+								<phase>package</phase>
+								<goals>
+									<goal>copy</goal>
+								</goals>
+								<configuration>
+									<artifactItems>
+										<artifactItem>
+											<groupId>org.mortbay.jetty</groupId>
+											<artifactId>jetty-runner</artifactId>
+											<version>8.1.3.v20120416</version>
+											<destFileName>jetty-runner.jar</destFileName>
+										</artifactItem>
+										<!-- not available in jetty-runner 8.1.3 -->
+										<artifactItem>
+											<groupId>javax.servlet</groupId>
+											<artifactId>com.springsource.javax.servlet.jsp.jstl</artifactId>
+											<version>1.2.0</version>
+											<destFileName>jstl.jar</destFileName>
+										</artifactItem>
+										<artifactItem>
+											<groupId>org.apache.taglibs</groupId>
+											<artifactId>com.springsource.org.apache.taglibs.standard</artifactId>
+											<version>1.1.2</version>
+											<destFileName>standard.jar</destFileName>
+										</artifactItem>
+									</artifactItems>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- Cargo configuration to execute integration tests -->
-        <!-- in an ad-hoc provisioned Tomcat container -->
-        <profile>
-            <id>cargo-tomcat</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
-                        <version>1.4.18</version>
-                        <configuration>
-                            <container>
-                                <containerId>tomcat8x</containerId>
-                                <zipUrlInstaller>
-                                    <url>${tomcat.downloadUrl}</url>
-                                </zipUrlInstaller>
-                            </container>
-                            <configuration>
-                                <properties>
-                                    <cargo.servlet.port>58080</cargo.servlet.port>
-                                    <cargo.tomcat.ajp.port>58009</cargo.tomcat.ajp.port>
-                                    <cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
-                                </properties>
-                            </configuration>
-                        </configuration>
-                        <executions>
-                            <!-- start server before integration tests -->
-                            <execution>
-                                <id>start-container</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <!-- stop server after integration tests -->
-                            <execution>
-                                <id>stop-container</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- Cargo configuration to execute integration tests -->
+		<!-- in an ad-hoc provisioned Tomcat container -->
+		<profile>
+			<id>cargo-tomcat</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.cargo</groupId>
+						<artifactId>cargo-maven2-plugin</artifactId>
+						<version>1.4.18</version>
+						<configuration>
+							<container>
+								<containerId>tomcat8x</containerId>
+								<zipUrlInstaller>
+									<url>${tomcat.downloadUrl}</url>
+								</zipUrlInstaller>
+							</container>
+							<configuration>
+								<properties>
+									<cargo.servlet.port>58080</cargo.servlet.port>
+									<cargo.tomcat.ajp.port>58009</cargo.tomcat.ajp.port>
+									<cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
+								</properties>
+							</configuration>
+						</configuration>
+						<executions>
+							<!-- start server before integration tests -->
+							<execution>
+								<id>start-container</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>start</goal>
+								</goals>
+							</execution>
+							<!-- stop server after integration tests -->
+							<execution>
+								<id>stop-container</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- Cargo configuration to execute integration tests -->
-        <!-- in an ad-hoc provisioned WildFly container -->
-        <profile>
-            <id>cargo-wildfly</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
-                        <version>1.4.18</version>
-                        <configuration>
-                            <container>
-                                <containerId>wildfly10x</containerId>
-                                <zipUrlInstaller>
-                                    <url>${wildfly.downloadUrl}</url>
-                                </zipUrlInstaller>
-                            </container>
-                            <configuration>
-                                <properties>
-                                    <cargo.servlet.port>58080</cargo.servlet.port>
-                                    <cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
-                                </properties>
-                            </configuration>
-                        </configuration>
-                        <executions>
-                            <!-- start server before integration tests -->
-                            <execution>
-                                <id>start-container</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <!-- stop server after integration tests -->
-                            <execution>
-                                <id>stop-container</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- Cargo configuration to execute integration tests -->
+		<!-- in an ad-hoc provisioned WildFly container -->
+		<profile>
+			<id>cargo-wildfly</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.cargo</groupId>
+						<artifactId>cargo-maven2-plugin</artifactId>
+						<version>1.4.18</version>
+						<configuration>
+							<container>
+								<containerId>wildfly10x</containerId>
+								<zipUrlInstaller>
+									<url>${wildfly.downloadUrl}</url>
+								</zipUrlInstaller>
+							</container>
+							<configuration>
+								<properties>
+									<cargo.servlet.port>58080</cargo.servlet.port>
+									<cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
+								</properties>
+							</configuration>
+						</configuration>
+						<executions>
+							<!-- start server before integration tests -->
+							<execution>
+								<id>start-container</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>start</goal>
+								</goals>
+							</execution>
+							<!-- stop server after integration tests -->
+							<execution>
+								<id>stop-container</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- Cargo configuration to execute integration tests -->
-        <!-- in an ad-hoc provisioned Jetty container -->
-        <profile>
-            <id>cargo-jetty</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
-                        <version>1.4.18</version>
-                        <configuration>
-                            <container>
-                                <containerId>jetty9x</containerId>
-                                <zipUrlInstaller>
-                                    <url>${jetty.downloadUrl}</url>
-                                </zipUrlInstaller>
-                            </container>
-                            <configuration>
-                                <properties>
-                                    <cargo.servlet.port>58080</cargo.servlet.port>
-                                    <cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
-                                </properties>
-                            </configuration>
-                        </configuration>
-                        <executions>
-                            <!-- start server before integration tests -->
-                            <execution>
-                                <id>start-container</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <!-- stop server after integration tests -->
-                            <execution>
-                                <id>stop-container</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- Cargo configuration to execute integration tests -->
+		<!-- in an ad-hoc provisioned Jetty container -->
+		<profile>
+			<id>cargo-jetty</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.cargo</groupId>
+						<artifactId>cargo-maven2-plugin</artifactId>
+						<version>1.4.18</version>
+						<configuration>
+							<container>
+								<containerId>jetty9x</containerId>
+								<zipUrlInstaller>
+									<url>${jetty.downloadUrl}</url>
+								</zipUrlInstaller>
+							</container>
+							<configuration>
+								<properties>
+									<cargo.servlet.port>58080</cargo.servlet.port>
+									<cargo.jvmargs>${jacoco.itAgentConfig}</cargo.jvmargs>
+								</properties>
+							</configuration>
+						</configuration>
+						<executions>
+							<!-- start server before integration tests -->
+							<execution>
+								<id>start-container</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>start</goal>
+								</goals>
+							</execution>
+							<!-- stop server after integration tests -->
+							<execution>
+								<id>stop-container</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- add Selenium integration tests -->
-        <profile>
-            <id>selenium-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.17</version>
-                        <configuration>
-                            <includes>
-                                <include>**/it/*IT.java</include>
-                            </includes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- add Selenium integration tests -->
+		<profile>
+			<id>selenium-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<includes>
+								<include>**/it/*IT.java</include>
+							</includes>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>integration-test</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- add JMeter integration tests -->
-        <profile>
-            <id>jmeter-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.lazerycode.jmeter</groupId>
-                        <artifactId>jmeter-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <configuration>
-                            <testResultsTimestamp>false</testResultsTimestamp>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>jmeter</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<!-- add Selenium integration tests -->
+		<profile>
+			<id>selenium-tests-all</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<includes>
+								<include>**/it/*IT*.java</include>
+							</includes>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>integration-test</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- add MongoDB integration tests -->
-        <profile>
-            <id>mongodb-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.17</version>
-                        <configuration>
-                            <includes>
-                                <include>**/mongo/*IT.java</include>
-                            </includes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-test</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>com.github.joelittlejohn.embedmongo</groupId>
-                        <artifactId>embedmongo-maven-plugin</artifactId>
-                        <version>${embedmongo.version}</version>
-                        <configuration>
-                            <port>57017</port>
-                            <version>${mongodb.version}</version>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>start</id>
-                                <phase>pre-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>stop</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>stop</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+		<profile>
+			<id>selenium-tests-po</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<includes>
+								<include>**/it/*ITPO.java</include>
+							</includes>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>integration-test</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 
-        <!-- add Pitest mutation tests (bound to unit test execution) -->
-        <profile>
-            <id>pitest-tests</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.pitest</groupId>
-                        <artifactId>pitest-maven</artifactId>
-                        <version>${pitest.version}</version>
-                        <configuration>
-                            <targetClasses>
-                                <param>org.springframework.samples.petclinic.*</param>
-                            </targetClasses>
-                            <excludedClasses>
-                                <param>org.springframework.samples.petclinic.it.*</param>
-                                <param>org.springframework.samples.petclinic.mongo.*</param>
-                            </excludedClasses>
-                            <outputFormats>
-                                <outputFormat>XML</outputFormat>
-                            </outputFormats>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>test</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>mutationCoverage</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
+		<!-- add JMeter integration tests -->
+		<profile>
+			<id>jmeter-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.lazerycode.jmeter</groupId>
+						<artifactId>jmeter-maven-plugin</artifactId>
+						<version>1.6.0</version>
+						<configuration>
+							<testResultsTimestamp>false</testResultsTimestamp>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>jmeter</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<!-- add MongoDB integration tests -->
+		<profile>
+			<id>mongodb-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-failsafe-plugin</artifactId>
+						<version>2.17</version>
+						<configuration>
+							<includes>
+								<include>**/mongo/*IT.java</include>
+							</includes>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<phase>integration-test</phase>
+								<goals>
+									<goal>integration-test</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>com.github.joelittlejohn.embedmongo</groupId>
+						<artifactId>embedmongo-maven-plugin</artifactId>
+						<version>${embedmongo.version}</version>
+						<configuration>
+							<port>57017</port>
+							<version>${mongodb.version}</version>
+						</configuration>
+						<executions>
+							<execution>
+								<id>start</id>
+								<phase>pre-integration-test</phase>
+								<goals>
+									<goal>start</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>stop</id>
+								<phase>post-integration-test</phase>
+								<goals>
+									<goal>stop</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<!-- add Pitest mutation tests (bound to unit test execution) -->
+		<profile>
+			<id>pitest-tests</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.pitest</groupId>
+						<artifactId>pitest-maven</artifactId>
+						<version>${pitest.version}</version>
+						<configuration>
+							<targetClasses>
+								<param>org.springframework.samples.petclinic.*</param>
+							</targetClasses>
+							<excludedClasses>
+								<param>org.springframework.samples.petclinic.it.*</param>
+								<param>org.springframework.samples.petclinic.mongo.*</param>
+							</excludedClasses>
+							<outputFormats>
+								<outputFormat>XML</outputFormat>
+							</outputFormats>
+						</configuration>
+						<executions>
+							<execution>
+								<id>test</id>
+								<phase>test</phase>
+								<goals>
+									<goal>mutationCoverage</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,9 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.17</version>
 				<configuration>
+					<!-- this will allow to run integration tests ignoring unit tests. The
+						parameter -Dskip.surefire.tests should be added while running maven -->
+					<skipTests>${skip.surefire.tests}</skipTests>
 					<!-- JDK 7 - relax bytecode verifier to prevent double -->
 					<!-- instrumentation issues with OpenJPA tests and JaCoCo -->
 					<!-- <argLine>-XX:-UseSplitVerifier ${jacoco.utAgentConfig}</argLine> -->
@@ -652,7 +655,8 @@
 			</build>
 		</profile>
 
-		<!-- add Selenium integration tests -->
+		<!-- add Selenium integration tests (will execute only regular integration
+			tests -->
 		<profile>
 			<id>selenium-tests</id>
 			<build>
@@ -680,7 +684,7 @@
 			</build>
 		</profile>
 
-		<!-- add Selenium integration tests -->
+		<!-- add Selenium integration tests (will execute all integration tests) -->
 		<profile>
 			<id>selenium-tests-all</id>
 			<build>
@@ -708,6 +712,8 @@
 			</build>
 		</profile>
 
+		<!-- add Selenium integration tests (will execute only page objects based
+			integration tests) -->
 		<profile>
 			<id>selenium-tests-po</id>
 			<build>

--- a/pom.xml
+++ b/pom.xml
@@ -667,8 +667,11 @@
 						<version>2.17</version>
 						<configuration>
 							<includes>
-								<include>**/it/*IT.java</include>
+								<include>**/it/*IT*.java</include>
 							</includes>
+							<excludes>
+								<exclude>**/it/*OP.java</exclude>
+							</excludes>
 						</configuration>
 						<executions>
 							<execution>
@@ -724,8 +727,11 @@
 						<version>2.17</version>
 						<configuration>
 							<includes>
-								<include>**/it/*ITPO.java</include>
+								<include>**/it/*IT*.java</include>
 							</includes>
+							<excludes>
+								<exclude>**/it/*IT.java</exclude>
+							</excludes>
 						</configuration>
 						<executions>
 							<execution>

--- a/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitIT.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitIT.java
@@ -26,104 +26,17 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 
-public class NewPetFirstVisitIT {
+public class NewPetFirstVisitIT extends TestSetupITBase {
 
     private static final Logger logger = LoggerFactory.getLogger(NewPetFirstVisitIT.class);
 
-    private static boolean RUN_HTMLUNIT;
+    /**
+    *
+    */
+   public NewPetFirstVisitIT() {
 
-    private static boolean RUN_IE;
-
-    private static boolean RUN_FIREFOX;
-
-    private static boolean RUN_CHROME;
-
-    private static boolean RUN_OPERA;
-
-    private static String SELENIUM_HUB_URL;
-
-    private static String TARGET_SERVER_URL;
-
-    @BeforeClass
-    public static void initEnvironment() {
-
-        RUN_HTMLUNIT = getConfigurationProperty(
-            "RUN_HTMLUNIT",
-            "test.run.htmlunit",
-            true);
-
-        logger.info("running the tests in HtmlUnit: " + RUN_HTMLUNIT);
-
-        RUN_IE = getConfigurationProperty(
-            "RUN_IE",
-            "test.run.ie",
-            false);
-
-        logger.info("running the tests in Internet Explorer: " + RUN_IE);
-
-        RUN_FIREFOX = getConfigurationProperty(
-            "RUN_FIREFOX",
-            "test.run.firefox",
-            false);
-
-        logger.info("running the tests in Firefox: " + RUN_FIREFOX);
-
-        RUN_CHROME = getConfigurationProperty(
-            "RUN_CHROME",
-            "test.run.chrome",
-            false);
-
-        logger.info("running the tests in Chrome: " + RUN_CHROME);
-
-        RUN_OPERA = getConfigurationProperty(
-            "RUN_OPERA",
-            "test.run.opera",
-            false);
-
-        logger.info("running the tests in Opera: " + RUN_OPERA);
-
-        SELENIUM_HUB_URL = getConfigurationProperty(
-            "SELENIUM_HUB_URL",
-            "test.selenium.hub.url",
-            "http://localhost:4444/wd/hub");
-
-        logger.info("using Selenium hub at: " + SELENIUM_HUB_URL);
-
-        TARGET_SERVER_URL = getConfigurationProperty(
-            "TARGET_SERVER_URL",
-            "test.target.server.url",
-            "http://localhost:58080/petclinic");
-
-        logger.info("using target server at: " + TARGET_SERVER_URL);
-    }
-
-    private static String getConfigurationProperty(String envKey, String sysKey, String defValue) {
-
-        String retValue = defValue;
-        String envValue = System.getenv(envKey);
-        String sysValue = System.getProperty(sysKey);
-        // system property prevails over environment variable
-        if (sysValue != null) {
-            retValue = sysValue;
-        } else if (envValue != null) {
-            retValue = envValue;
-        }
-        return retValue;
-    }
-
-    private static boolean getConfigurationProperty(String envKey, String sysKey, boolean defValue) {
-
-        boolean retValue = defValue;
-        String envValue = System.getenv(envKey);
-        String sysValue = System.getProperty(sysKey);
-        // system property prevails over environment variable
-        if (sysValue != null) {
-            retValue = Boolean.parseBoolean(sysValue);
-        } else if (envValue != null) {
-            retValue = Boolean.parseBoolean(envValue);
-        }
-        return retValue;
-    }
+       super();
+   }
 
     @Test
     public void testHtmlUnit()
@@ -331,8 +244,8 @@ public class NewPetFirstVisitIT {
             Point loc = e.getLocation();
             Dimension size = e.getSize();
 
-            logger.info("  found element {} at position ({},{}) with size ({},{})",
-                new Object[] {e.getTagName(), loc.getX(), loc.getY(), size.getWidth(), size.getHeight()});
+            logger.info("  found element {} with content \"{}\" at position ({},{}) with size ({},{})",
+                new Object[] {e.getTagName(), e.getText(), loc.getX(), loc.getY(), size.getWidth(), size.getHeight()});
         }
     }
 

--- a/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitITPO.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitITPO.java
@@ -129,43 +129,6 @@ public class NewPetFirstVisitITPO
         }
     }
 
-    public void testNewPetFirstVisitFull(final WebDriver driver, final String baseUrl) {
-
-        driver.get(baseUrl);
-
-        HomePage homePage = new HomePage(driver, baseUrl);
-
-        FindOwnersPage findOwnersPage = homePage.navigateToFindOwners();
-
-        OwnerPage ownerPage = findOwnersPage.findOwner("Schroeder");
-        assertTrue("owner page not found", ownerPage.verifyPage());
-        assertTrue("incorrect owner name while searching", ownerPage.getName().contains("David Schroeder"));
-
-        PetPage petPage = ownerPage.navigateToAddNewPet();
-        assertTrue("pet page not found", petPage.verifyPage());
-
-        petPage.createPet("Mimi", "2011-10-02");
-        assertTrue("owner page not found", ownerPage.verifyPage());
-        assertTrue("incorrect owner name after adding pet", ownerPage.getName().contains("David Schroeder"));
-        assertTrue("pet name not found", ownerPage.getMainText().contains("Mimi"));
-        assertTrue("pet birthdate not found", ownerPage.getMainText().contains("2011-10-02"));
-
-        VisitPage visitPage = ownerPage.navigateToAddNewVisit();
-        assertTrue("visit page not found", visitPage.verifyPage());
-
-        visitPage.createVisit("2012-03-15", "rabies shot");
-        assertTrue("visit page not found", ownerPage.verifyPage());
-        assertTrue("incorrect owner name after adding the visit", ownerPage.getName().contains("David Schroeder"));
-        assertTrue("pet name not found after adding the visit", ownerPage.getMainText().contains("Mimi"));
-        assertTrue("visit date not found", ownerPage.getMainText().contains("2012-03-15"));
-        assertTrue("visit description not found", ownerPage.getMainText().contains("rabies shot"));
-
-        petPage = ownerPage.navigateToEditPet();
-        assertTrue("pet page not found", petPage.verifyPage());
-
-        petPage.deletePet();
-    }
-
     public void testNewPetFirstVisit(final WebDriver driver, final String baseUrl) {
 
         driver.get(baseUrl);

--- a/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitITPO.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/NewPetFirstVisitITPO.java
@@ -1,0 +1,201 @@
+package org.springframework.samples.petclinic.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.samples.petclinic.it.page.FindOwnersPage;
+import org.springframework.samples.petclinic.it.page.HomePage;
+import org.springframework.samples.petclinic.it.page.OwnerPage;
+import org.springframework.samples.petclinic.it.page.PetPage;
+import org.springframework.samples.petclinic.it.page.VisitPage;
+
+public class NewPetFirstVisitITPO
+    extends TestSetupITBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewPetFirstVisitITPO.class);
+
+    /**
+     *
+     */
+    public NewPetFirstVisitITPO() {
+
+        super();
+    }
+
+    @Test
+    public void testHtmlUnit() throws MalformedURLException, IOException {
+
+        logger.info("will starting tests in HTMLUNIT...");
+
+        Assume.assumeTrue(RUN_HTMLUNIT);
+
+        WebDriver driver = new HtmlUnitDriver();
+
+        try {
+            testNewPetFirstVisit(driver, TARGET_SERVER_URL);
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    @Test
+    public void testIE() throws MalformedURLException, IOException {
+
+        logger.info("will starting tests in IE...");
+
+        Assume.assumeTrue(RUN_IE);
+
+        Capabilities browser = DesiredCapabilities.internetExplorer();
+        WebDriver driver = new RemoteWebDriver(new URL(SELENIUM_HUB_URL), browser);
+
+        try {
+            testNewPetFirstVisit(driver, TARGET_SERVER_URL);
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    @Test
+    public void testFirefox() throws MalformedURLException, IOException {
+
+        logger.info("will starting tests in FIREFOX...");
+
+        Assume.assumeTrue(RUN_FIREFOX);
+
+        Capabilities browser = DesiredCapabilities.firefox();
+        WebDriver driver = new RemoteWebDriver(new URL(SELENIUM_HUB_URL), browser);
+
+        try {
+            testNewPetFirstVisit(driver, TARGET_SERVER_URL);
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    @Test
+    public void testChrome() throws MalformedURLException, IOException {
+
+        logger.info("will starting tests in CHROME...");
+
+        Assume.assumeTrue(RUN_CHROME);
+
+        Capabilities browser = DesiredCapabilities.chrome();
+        WebDriver driver = new RemoteWebDriver(new URL(SELENIUM_HUB_URL), browser);
+
+        try {
+            testNewPetFirstVisit(driver, TARGET_SERVER_URL);
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    @Test
+    public void testOpera() throws MalformedURLException, IOException {
+
+        logger.info("will starting tests in OPERA...");
+
+        Assume.assumeTrue(RUN_OPERA);
+
+        Capabilities browser = DesiredCapabilities.operaBlink();
+        WebDriver driver = new RemoteWebDriver(new URL(SELENIUM_HUB_URL), browser);
+
+        try {
+            testNewPetFirstVisit(driver, TARGET_SERVER_URL);
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+        }
+    }
+
+    public void testNewPetFirstVisitFull(final WebDriver driver, final String baseUrl) {
+
+        driver.get(baseUrl);
+
+        HomePage homePage = new HomePage(driver, baseUrl);
+
+        FindOwnersPage findOwnersPage = homePage.navigateToFindOwners();
+
+        OwnerPage ownerPage = findOwnersPage.findOwner("Schroeder");
+        assertTrue("owner page not found", ownerPage.verifyPage());
+        assertTrue("incorrect owner name while searching", ownerPage.getName().contains("David Schroeder"));
+
+        PetPage petPage = ownerPage.navigateToAddNewPet();
+        assertTrue("pet page not found", petPage.verifyPage());
+
+        petPage.createPet("Mimi", "2011-10-02");
+        assertTrue("owner page not found", ownerPage.verifyPage());
+        assertTrue("incorrect owner name after adding pet", ownerPage.getName().contains("David Schroeder"));
+        assertTrue("pet name not found", ownerPage.getMainText().contains("Mimi"));
+        assertTrue("pet birthdate not found", ownerPage.getMainText().contains("2011-10-02"));
+
+        VisitPage visitPage = ownerPage.navigateToAddNewVisit();
+        assertTrue("visit page not found", visitPage.verifyPage());
+
+        visitPage.createVisit("2012-03-15", "rabies shot");
+        assertTrue("visit page not found", ownerPage.verifyPage());
+        assertTrue("incorrect owner name after adding the visit", ownerPage.getName().contains("David Schroeder"));
+        assertTrue("pet name not found after adding the visit", ownerPage.getMainText().contains("Mimi"));
+        assertTrue("visit date not found", ownerPage.getMainText().contains("2012-03-15"));
+        assertTrue("visit description not found", ownerPage.getMainText().contains("rabies shot"));
+
+        petPage = ownerPage.navigateToEditPet();
+        assertTrue("pet page not found", petPage.verifyPage());
+
+        petPage.deletePet();
+    }
+
+    public void testNewPetFirstVisit(final WebDriver driver, final String baseUrl) {
+
+        driver.get(baseUrl);
+
+        HomePage homePage = new HomePage(driver, baseUrl);
+
+        FindOwnersPage findOwnersPage = homePage.navigateToFindOwners();
+
+        OwnerPage ownerPage = findOwnersPage.findOwner("Schroeder");
+        assertTrue(ownerPage.getName().contains("David Schroeder"));
+
+        PetPage petPage = ownerPage.navigateToAddNewPet();
+
+        petPage.createPet("Mimi", "2011-10-02");
+        assertTrue(ownerPage.getName().contains("David Schroeder"));
+        assertTrue(ownerPage.getMainText().contains("Mimi"));
+        assertTrue(ownerPage.getMainText().contains("2011-10-02"));
+
+        VisitPage visitPage = ownerPage.navigateToAddNewVisit();
+
+        visitPage.createVisit("2012-03-15", "rabies shot");
+        assertTrue(ownerPage.getName().contains("David Schroeder"));
+        assertTrue(ownerPage.getMainText().contains("Mimi"));
+        assertTrue(ownerPage.getMainText().contains("2012-03-15"));
+        assertTrue(ownerPage.getMainText().contains("rabies shot"));
+
+        petPage = ownerPage.navigateToEditPet();
+        assertTrue("pet page not found", petPage.verifyPage());
+
+        petPage.deletePet();
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/TestSetupITBase.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/TestSetupITBase.java
@@ -1,0 +1,87 @@
+package org.springframework.samples.petclinic.it;
+
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestSetupITBase {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestSetupITBase.class);
+
+    protected static boolean RUN_HTMLUNIT;
+
+    protected static boolean RUN_IE;
+
+    protected static boolean RUN_FIREFOX;
+
+    protected static boolean RUN_CHROME;
+
+    protected static boolean RUN_OPERA;
+
+    protected static String SELENIUM_HUB_URL;
+
+    protected static String TARGET_SERVER_URL;
+
+    @BeforeClass
+    public static void initEnvironment() {
+
+        RUN_HTMLUNIT = getConfigurationProperty("RUN_HTMLUNIT", "test.run.htmlunit", true);
+
+        logger.info("running the tests in HtmlUnit: " + RUN_HTMLUNIT);
+
+        RUN_IE = getConfigurationProperty("RUN_IE", "test.run.ie", false);
+
+        logger.info("running the tests in Internet Explorer: " + RUN_IE);
+
+        RUN_FIREFOX = getConfigurationProperty("RUN_FIREFOX", "test.run.firefox", false);
+
+        logger.info("running the tests in Firefox: " + RUN_FIREFOX);
+
+        RUN_CHROME = getConfigurationProperty("RUN_CHROME", "test.run.chrome", false);
+
+        logger.info("running the tests in Chrome: " + RUN_CHROME);
+
+        RUN_OPERA = getConfigurationProperty("RUN_OPERA", "test.run.opera", false);
+
+        logger.info("running the tests in Opera: " + RUN_OPERA);
+
+        SELENIUM_HUB_URL =
+            getConfigurationProperty("SELENIUM_HUB_URL", "test.selenium.hub.url", "http://localhost:4444/wd/hub");
+
+        logger.info("using Selenium hub at: " + SELENIUM_HUB_URL);
+
+        TARGET_SERVER_URL =
+            getConfigurationProperty("TARGET_SERVER_URL", "test.target.server.url", "http://localhost:58080/petclinic");
+
+        logger.info("using target server at: " + TARGET_SERVER_URL);
+    }
+
+    private static String getConfigurationProperty(String envKey, String sysKey, String defValue) {
+
+        String retValue = defValue;
+        String envValue = System.getenv(envKey);
+        String sysValue = System.getProperty(sysKey);
+        // system property prevails over environment variable
+        if (sysValue != null) {
+            retValue = sysValue;
+        } else if (envValue != null) {
+            retValue = envValue;
+        }
+        return retValue;
+    }
+
+    private static boolean getConfigurationProperty(String envKey, String sysKey, boolean defValue) {
+
+        boolean retValue = defValue;
+        String envValue = System.getenv(envKey);
+        String sysValue = System.getProperty(sysKey);
+        // system property prevails over environment variable
+        if (sysValue != null) {
+            retValue = Boolean.parseBoolean(sysValue);
+        } else if (envValue != null) {
+            retValue = Boolean.parseBoolean(envValue);
+        }
+        return retValue;
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/FindOwnersPage.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/FindOwnersPage.java
@@ -1,0 +1,107 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+public class FindOwnersPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(FindOwnersPage.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // label of the title of this page
+    private String titleLabel = "Owner Information";
+
+    // elements
+    private By titleElement = By.xpath("//h2");
+    private By lastNameField = By.id("lastName");
+    private By addOwnerCommand = By.id("addOwner");
+    private By findOwnersCommand = By.id("findowners");
+
+    /**
+     * Constructor for the FindOwnersPage object with the driver and baseURL as parameters
+     *
+     * @param driver
+     * @param baseUrl
+     */
+    public FindOwnersPage(WebDriver driver, String baseUrl) {
+
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * @return the HTML title
+     */
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    /**
+     * @return the URL of the current page.
+     */
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return title label of the page (window title is the same for all pages)
+     */
+    public String getTitleLabel() {
+
+        return titleLabel;
+    }
+
+    /**
+     * Method used to verify that the page loaded is the one expected. This is done by matching the
+     * Label of the title within the header tags
+     *
+     * @return true if the page contains the title label expected
+     */
+    public boolean verifyPage() {
+
+        WebElement title = driver.findElement(titleElement);
+        logger.debug("\t-- -- verifying page with title: \"" + title.getText() + "\" contains(\"" + getTitleLabel()+"\")");
+        return title.getText().contains(getTitleLabel());
+    }
+
+    /**
+     * This method invokes the search of the Owner passed by the parameter ownerToFind. It first
+     * clear the content of the LastName input and then populated the input with the value of the
+     * ownerToFind parameter
+     *
+     * @param ownerToFind the owner to look for.
+     * @return the {@link org.springframework.samples.petclinic.it.page.OwnerPage} that represents
+     *         the Owner Page where data of the owner are maintained
+     */
+    public OwnerPage findOwner(String ownerToFind) {
+
+        logger.info("\t-- getting owner information" );
+
+        logger.debug("\t-- -- before find owner "+ ownerToFind + "current URL:"+ driver.getCurrentUrl());
+
+        driver.findElement(lastNameField).clear();
+        driver.findElement(lastNameField).sendKeys(ownerToFind);
+        driver.findElement(findOwnersCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().equals(
+            baseUrl + "/owners/9"));
+
+        logger.debug("\t-- -- after find owner: current URL:" + driver.getCurrentUrl());
+
+        return new OwnerPage(driver, baseUrl);
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/HomePage.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/HomePage.java
@@ -1,0 +1,84 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.samples.petclinic.it.TestSetupITBase;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+
+public class HomePage {
+
+    private static final Logger logger = LoggerFactory.getLogger(HomePage.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // elements
+    private By findOwnersCommand = By.linkText("Find owner");
+    private By displayVeterinariansCommand = By.linkText("Display all veterinarians");
+    private By displayTutorialCommand = By.linkText("Tutorial");
+    private By linkToHome = By.linkText("Home");
+
+    WebElement findOwnerLink;
+
+    public HomePage(WebDriver driver, final String baseUrl) {
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+        logger.info("\t-- home page: " + driver.getCurrentUrl());
+    }
+
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return the link to the Find Owners page
+     * @see WebElement
+     */
+    private WebElement getFindOwnerLink() {
+
+        WebElement findOwnerLink =
+            (new WebDriverWait(driver, 5)).until((Function<WebDriver, WebElement>) d -> d
+                .findElement(findOwnersCommand));
+        return findOwnerLink;
+    }
+
+
+    /**
+     * Navigate to the FindOwnersPage
+     *
+     * @return the abstract representation of the FindOwnersPage
+     * @see FindOwnersPage
+     */
+    public FindOwnersPage navigateToFindOwners() {
+
+        logger.info("\t-- moving to find owners page");
+
+        logger.debug("\t-- -- before moving to find owners page current URL is:" + driver.getCurrentUrl());
+
+        // click on the link to the find owners page
+        getFindOwnerLink().click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl()
+            .startsWith(baseUrl + "/owners/search"));
+
+        logger.debug("\t-- -- afger moving to find owners page current URL is:" + driver.getCurrentUrl());
+
+        return new FindOwnersPage(driver, baseUrl);
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/OwnerPage.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/OwnerPage.java
@@ -1,0 +1,215 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+/**
+ * Abstraction for OwnerPage
+ *
+ * @author vicente.gonzalez
+ *
+ */
+public class OwnerPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(OwnerPage.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // page title
+    private String titleLabel = "Owner Information";
+
+    // Elements
+    private By titleElement = By.xpath("//h2");
+    private By mainContent = By.id("main");
+    private By editOwnerCommand = By.linkText("Edit Owner");
+    private By addNewPetCommand = By.linkText("Add New Pet");
+    private By editPetCommand = By.linkText("Edit Pet");
+    private By addVisitCommand = By.linkText("Add Visit");
+    private By linkToHome = By.linkText("Home");
+    private By nameTag = By.xpath("//table[1]/tbody/tr[1]/td");
+    private By addressTag = By.xpath("//table[1]/tbody/tr[2]/td");
+
+
+    /**
+     * OwnerPage abstraction constructor
+     *
+     * @param driver
+     * @param baseUrl
+     */
+    public OwnerPage(WebDriver driver, String baseUrl) {
+
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * @return title page
+     */
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    /**
+     * @return current URL
+     */
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return title label of the page (window title is the same for all pages)
+     */
+    public String getTitleLabel() {
+
+        return titleLabel;
+    }
+
+    /**
+     * Method used to verify that the page loaded is the one expected. This is done by matching the
+     * Label of the title within the header tags
+     *
+     * @return true if the page contains the title label expected
+     */
+    public boolean verifyPage() {
+
+        WebElement title = driver.findElement(titleElement);
+        logger.debug("\t-- -- verifying page with title: \"" + title.getText() + "\" contains(\"" + getTitleLabel()+"\")");
+        return title.getText().contains(getTitleLabel());
+    }
+
+    /**
+     * @return the full text within the "main" id
+     */
+    public String getMainText() {
+
+        WebElement element = driver.findElement(mainContent);
+        String pageText = element.getText();
+        logger.debug("\t-- -- page text: " + pageText);
+
+        return pageText;
+    }
+
+    public String getName() {
+
+        WebElement element = driver.findElement(nameTag);
+        String name = element.getText();
+        logger.debug("\t-- -- name:" + element.getText());
+        return name;
+    }
+
+    public String getAddress() {
+
+        WebElement element = driver.findElement(addressTag);
+        String address = element.getText();
+        logger.debug("\t-- -- adress:" + element.getText());
+        return address;
+    }
+
+    /**
+     * Navigate to the PetPage for adding pets to a selected owner
+     *
+     * @return the abstraction for the New Pet Page
+     *
+     * @see PetPage
+     */
+    public PetPage navigateToAddNewPet() {
+
+        logger.info("\t-- moving to the new pet page for adding a pet");
+
+        logger.debug("\t-- -- before navigate to add new pet: current URL is:"+  driver.getCurrentUrl());
+
+        driver.findElement(addNewPetCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().equals(
+            baseUrl + "/owners/9/pets/new"));
+
+        logger.debug("\t-- -- after navigate to add new pet: current driver is:" + driver.getCurrentUrl());
+
+        return new PetPage(driver, baseUrl);
+    }
+
+    /**
+     * Navigate to the PetPage for adding pets to a selected owner
+     *
+     * @return the abstraction for the New Pet Page
+     *
+     * @see PetPage
+     */
+    public PetPage navigateToEditPet() {
+
+        logger.info("\t-- moving to the edit pet page for removing the pet");
+
+        logger.debug("\t-- -- before navigate to edit pet: current URL is:" + driver.getCurrentUrl());
+
+        driver.findElement(editPetCommand).click();
+
+        (new WebDriverWait(driver, 5)).until(
+            (Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(baseUrl + "/owners/9/pets")
+                && d.getCurrentUrl().contains("edit"));
+
+        logger.debug("\t-- -- after navigate to edit pet: current URL is:" + driver.getCurrentUrl());
+
+        return new PetPage(driver, baseUrl);
+    }
+
+    /**
+     * Navigate to the AddVisit page for the selected owner
+     * @return the abstraction for the New Visit Page
+     *
+     * @see VisitPage
+     */
+    public VisitPage navigateToAddNewVisit() {
+
+        logger.info("\t-- moving to the new visit page for adding a visit for the pet ");
+
+        logger.debug("-- -- before navigate to add new visit: current URL is:" + driver.getCurrentUrl());
+
+        driver.findElement(addVisitCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(
+            baseUrl + "/owners/9/pets")
+            && d.getCurrentUrl().contains("visits/new"));
+
+        logger.debug("\t-- -- after navigate to add new visit: current driver is:" + driver.getCurrentUrl());
+
+        return new VisitPage(driver, baseUrl);
+
+    }
+
+    /**
+     * Navigate to the AddVisit page for the selected owner
+     * @return the abstraction for the New Visit Page
+     *
+     * @see VisitPageFactory
+     */
+    public VisitPageFactory navigateToAddNewVisitFromFactory() {
+
+        logger.info("\t-- moving to the new visit page for adding a visit for the pet ");
+
+        logger.debug("\t-- -- before navigate to add new visit: current URL is:" + driver.getCurrentUrl());
+
+        driver.findElement(addVisitCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(
+            baseUrl + "/owners/9/pets")
+            && d.getCurrentUrl().contains("visits/new"));
+
+        logger.debug("\t-- -- after navigate to add new visit: current URL is:" + driver.getCurrentUrl());
+
+        return new VisitPageFactory(driver, baseUrl);
+
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/PetPage.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/PetPage.java
@@ -1,0 +1,143 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+/**
+ * @author vicente.gonzalez
+ *
+ */
+public class PetPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(PetPage.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // page title
+    private String titleLabel = "Pet";
+
+    // elements
+    private By titleElement = By.xpath("//h2");
+    private By mainContent = By.id("main");
+    private By name = By.id("name");
+    private By birthDate = By.id("birthDate");
+    private By addPetCommand = By.id("addpet");
+    private By deletePetCommand = By.id("deletepet");
+    private By linkToHome = By.linkText("Home");
+
+    /**
+     * Constructor using a driver and a baseURL
+     *
+     * @param driver
+     * @param baseUrl
+     */
+    public PetPage(WebDriver driver, String baseUrl) {
+
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * @return title page
+     */
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    /**
+     * @return current URL
+     */
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return the label used for the title in the page
+     */
+    public String getTitleLabel() {
+
+        return titleLabel;
+    }
+
+    /**
+     * @return the full text within the "main" id
+     */
+    public String getMainText() {
+
+        WebElement element = driver.findElement(mainContent);
+        String pageText = element.getText();
+        logger.debug("\t-- -- page text: " + pageText);
+
+        return pageText;
+    }
+
+    /**
+     * Method used to verify that the page loaded is the one expected. This is done by matching the
+     * Label of the title within the header tags
+     *
+     * @return true if the page contains the title label expected
+     */
+    public boolean verifyPage() {
+
+        WebElement title = driver.findElement(titleElement);
+        logger.debug("\t-- -- verifying page with title: \"" + title.getText() + "\" contains(\"" + getTitleLabel()+"\")");
+        return title.getText().contains(getTitleLabel());
+    }
+
+    /**
+     * Method that creates a Pet with the name and the birthdate received as parameters
+     *
+     * @param currentWebDriver
+     * @param petName The name of the new Pet
+     * @param petBirthDate The birthdate of the Pet
+     */
+    public void createPet(String petName, String petBirthDate) {
+
+        logger.info("\t\t-- adding new pet");
+
+        logger.debug("\t-- -- before create pet current URL is:" + driver.getCurrentUrl());
+
+        driver.findElement(name).clear();
+        driver.findElement(name).sendKeys(petName);
+        driver.findElement(birthDate).clear();
+        driver.findElement(birthDate).sendKeys(petBirthDate);
+        driver.findElement(addPetCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(
+            baseUrl + "/owners/9")
+            && !d.getCurrentUrl().contains("pets/new"));
+
+        logger.debug("\t-- -- after create pet current driver is:" + driver.getCurrentUrl());
+
+    }
+
+    /**
+     *
+     */
+    public void deletePet() {
+
+        logger.info("\t\t-- removing the pet");
+
+        logger.debug("\t-- -- before deleting pet : current URL is:" + driver.getCurrentUrl());
+
+        driver.findElement(deletePetCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl()
+            .equals(baseUrl + "/owners/9"));
+
+        logger.debug("\t-- -- after deleting pet : current driver is:" + driver.getCurrentUrl());
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/VisitPage.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/VisitPage.java
@@ -1,0 +1,126 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+/**
+ * @author vicente.gonzalez
+ *
+ */
+public class VisitPage {
+
+    private static final Logger logger = LoggerFactory.getLogger(VisitPage.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // page title
+    private String titleLabel = "Visit";
+
+    // elements
+    private By mainContent = By.id("main");
+    private By titleElement = By.xpath("//h2");
+    private By visitForm = By.id("visit");
+    private By dateField = By.id("date");
+    private By descriptionField = By.id("description");
+    private By addVisitCommand = By.id("addvisit");
+    private By linkToHome = By.linkText("Home");
+
+    /**
+     * Constructor using a driver and a baseURL
+     *
+     * @param driver
+     * @param baseUrl
+     */
+    public VisitPage(WebDriver driver, String baseUrl) {
+
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+    }
+
+    /**
+     * @return title page
+     */
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    /**
+     * @return current URL
+     */
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return the label used for the title in the page
+     */
+    public String getTitleLabel() {
+
+        return titleLabel;
+    }
+
+    /**
+     * @return the full text within the "main" id
+     */
+    public String getMainText() {
+
+        WebElement element = driver.findElement(mainContent);
+        String pageText = element.getText();
+        logger.debug("-- -- page text: " + pageText);
+
+        return pageText;
+    }
+
+    /**
+     * Method used to verify that the page loaded is the one expected. This is done by matching the
+     * Label of the title within the header tags
+     *
+     * @return true if the page contains the title label expected
+     */
+    public boolean verifyPage() {
+
+        WebElement title = driver.findElement(titleElement);
+        logger.debug("\t-- -- verifying page with title: \"" + title.getText() + "\" contains(\"" + getTitleLabel()+"\")");
+        return title.getText().contains(getTitleLabel());
+    }
+
+    /**
+     * Method that creates a visit for a given pet at the date received by parameters and with the
+     * description provided
+     *
+     * @param date
+     * @param description
+     */
+    public void createVisit(String date, String description) {
+
+        logger.info("\t-- creating a visit for the pet: ");
+
+        logger.debug("\t-- -- before create visit: current URL:" + driver.getCurrentUrl());
+
+        driver.findElement(dateField).clear();
+        driver.findElement(dateField).sendKeys(date);
+        driver.findElement(descriptionField).clear();
+        driver.findElement(descriptionField).sendKeys(description);
+        driver.findElement(addVisitCommand).click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(
+            baseUrl + "/owners/9")
+            && !d.getCurrentUrl().contains("pets/new"));
+
+        logger.debug("\t-- -- after create visit current driver is:" + driver.getCurrentUrl());
+
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/it/page/VisitPageFactory.java
+++ b/src/test/java/org/springframework/samples/petclinic/it/page/VisitPageFactory.java
@@ -1,0 +1,142 @@
+package org.springframework.samples.petclinic.it.page;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+
+/**
+ * @author vicente.gonzalez
+ *
+ */
+public class VisitPageFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(VisitPageFactory.class);
+
+    private WebDriver driver;
+
+    private String baseUrl;
+
+    // page title
+    private String titleLabel = "Visit";
+
+    // elements
+
+    @FindBy(id="main")
+    WebElement mainContent;
+
+    @FindBy(xpath="//h2")
+    WebElement titleElement;
+
+    @FindBy(id="visit")
+    WebElement visitForm;
+
+    @FindBy(id="date")
+    WebElement dateField;
+
+    @FindBy(id="description")
+    WebElement descriptionField;
+
+    @FindBy(id="addvisit")
+    WebElement addVisitCommand;
+
+    @FindBy(linkText="Home")
+    WebElement linkToHome;
+
+    /**
+     * Constructor using a driver and a baseURL
+     *
+     * @param driver
+     * @param baseUrl
+     */
+    public VisitPageFactory(WebDriver driver, String baseUrl) {
+
+        logger.info("****Ey JavaOners... I am now using a Factory!!!!");
+        this.driver = driver;
+        this.baseUrl = baseUrl;
+        PageFactory.initElements(driver, this);
+
+    }
+
+    /**
+     * @return title page
+     */
+    public String getPageTitle() {
+
+        String pageTitle = driver.getTitle();
+        return pageTitle;
+    }
+
+    /**
+     * @return current URL
+     */
+    public String getUrl() {
+
+        String pageURL = driver.getCurrentUrl();
+        return pageURL;
+    }
+
+    /**
+     * @return the label used for the title in the page
+     */
+    public String getTitleLabel() {
+
+        return titleLabel;
+    }
+
+    /**
+     * @return the full text within the "main" id
+     */
+    public String getMainText() {
+
+        String pageText = mainContent.getText();
+        logger.debug("\t-- -- page text: " + pageText);
+
+        return pageText;
+    }
+
+    /**
+     * Method used to verify that the page loaded is the one expected. This is done by matching the
+     * Label of the title within the header tags
+     *
+     * @return true if the page contains the title label expected
+     */
+    public boolean verifyPage() {
+
+        logger.debug("\t-- -- verifying page with title: \"" + titleElement.getText() + "\" contains(\"" + getTitleLabel()+"\")");
+        return titleElement.getText().contains(getTitleLabel());
+    }
+
+    /**
+     * Method that creates a visit for a given pet at the date received by parameters and with the
+     * description provided
+     *
+     * @param date
+     * @param description
+     */
+    public void createVisit(String date, String description) {
+
+        logger.info("\t-- creating a visit");
+
+        logger.debug("\t-- -- before create visit current driver is:" + driver.getCurrentUrl());
+
+        dateField.clear();
+        dateField.sendKeys(date);
+        descriptionField.clear();
+        descriptionField.sendKeys(description);
+        addVisitCommand.click();
+
+        (new WebDriverWait(driver, 5)).until((Predicate<WebDriver>) d -> d.getCurrentUrl().startsWith(
+            baseUrl + "/owners/9")
+            && !d.getCurrentUrl().contains("pets/new"));
+
+        logger.debug("\t-- -- after create visit current driver is:" + driver.getCurrentUrl());
+
+    }
+
+}


### PR DESCRIPTION
- I have created a set of pages for performing Selenium tests using POM pattern. They are all located under the new package `org.springframework.samples.petclinic.it.page`. One of the classes includes an example on using `PageFactory` for using POM pattern tests. 

- I have also added a new class with the test cases covering the same tests as the regular tests but using the POM pattern. This is the new test class `NewPetFirstVisitITPO`. This new test class extends a new `TestSetupITBase` that contains the `initEnvironment` method originally at the `NewPetFirstVisitIT` test clases that now also extends the new `TestSetupITBase`

- In addition I have updated the POM configuration file by modifying the profiles sections. Current profiles runs as following:

1. `selenium-tests ` the existing one that allow to perform regular selenium tests
2.`selenium-tests-all` allows to run all IT tests (including regular and POM based tests)
3.`selenium-tests-po` allows to run only the POM based test cases

- A minor addition to that.  I have added to the POM fille that will allow to execute integration tests  by excluding surefire tests by adding the paramter `-Dskip.surefire.tests` while running maven. 